### PR TITLE
[Bugfix] Explicitly requiring base_bot & Hero position variables

### DIFF
--- a/env.rb
+++ b/env.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'bundler'
 require 'json'
+require './bots/base_bot.rb'
 
 Bundler.setup
 Bundler.require

--- a/models/hero.rb
+++ b/models/hero.rb
@@ -7,8 +7,8 @@ class Hero
     self.pos = hero['pos']
     self.life = hero['life']
     self.gold = hero['gold']
-    self.x = hero['x']
-    self.y = hero['y']
+    self.x = self.pos['x']
+    self.y = self.pos['y']
   end
 
 end


### PR DESCRIPTION
Base bot should be included before any other bot as it now throws this exception : 
```
/home/mohamedbassem/repos/vindinium-starter-ruby/bots/random_bot.rb:1:in `<top (required)>': uninitialized constant BaseBot (NameError)
	from /home/mohamedbassem/repos/vindinium-starter-ruby/env.rb:19:in `require'
	from /home/mohamedbassem/repos/vindinium-starter-ruby/env.rb:19:in `block (2 levels) in <top (required)>'
	from /home/mohamedbassem/repos/vindinium-starter-ruby/env.rb:18:in `each'
	from /home/mohamedbassem/repos/vindinium-starter-ruby/env.rb:18:in `block in <top (required)>'
	from /home/mohamedbassem/repos/vindinium-starter-ruby/env.rb:17:in `each'
	from /home/mohamedbassem/repos/vindinium-starter-ruby/env.rb:17:in `<top (required)>'
	from client.rb:1:in `require'
	from client.rb:1:in `<main>'
```

Also the position variables in the hero model doesn't map to anything in the json. It should be self.pos['x'] instead of self.state['x']